### PR TITLE
Refactor common module to avoid setuptools import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.1.8
+=====
+- Refactor to support early import of ppbt.common at relenv runtime.
+
+
 0.1.7
 =====
 - Use tar instead of tarfile to create toolchain tarballs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires = [
     "wheel>=0.31.0",
     "twine>=1.11.0"
 ]
-build-backend = "build"
-backend-path = ["src/ppbt"]
+build-backend = "ppbt.build"
+backend-path = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/src/ppbt/common.py
+++ b/src/ppbt/common.py
@@ -8,42 +8,109 @@ Toolchain build environment.
 import csv
 import logging
 import pathlib
+import platform
+import sys
+import tarfile
 
-from .build import build_arch, extract_archive, get_triplet
+__version__ = "0.1.8"
 
-__version__ = "0.1.7"
+log = logging.getLogger(__name__)
 
-triplet = get_triplet(build_arch())
 
-archive = pathlib.Path(__file__).parent / "_toolchain" / f"{triplet}.tar.xz"
-toolchain = pathlib.Path(__file__).parent / "_toolchain" / triplet
-toolchain_root = pathlib.Path(__file__).parent / "_toolchain"
+class PPBTException(Exception):
+    """
+    Base class for all ppbt exceptions.
+
+    """
+
+
+def get_triplet(machine=None, plat=None):
+    """
+    Get the target triplet for the specified machine and platform.
+
+    If any of the args are None, it will try to deduce what they should be.
+
+    :param machine: The machine for the triplet
+    :type machine: str
+    :param plat: The platform for the triplet
+    :type plat: str
+
+    :raises BuildError: If the platform is unknown
+
+    :return: The target triplet
+    :rtype: str
+    """
+    if not plat:
+        plat = sys.platform
+    if not machine:
+        machine = build_arch()
+    if plat == "darwin":
+        return f"{machine}-macos"
+    elif plat == "win32":
+        return f"{machine}-win"
+    elif plat == "linux":
+        return f"{machine}-linux-gnu"
+    else:
+        raise PPBTException(f"Unknown platform {plat}")
+
+
+def build_arch():
+    """
+    Return the current machine.
+    """
+    machine = platform.machine()
+    return machine.lower()
+
+
+TRIPLET = get_triplet(build_arch())
+ARCHIVE = pathlib.Path(__file__).parent / "_toolchain" / f"{TRIPLET}.tar.xz"
+TOOLCHAIN_ROOT = pathlib.Path(__file__).parent / "_toolchain"
+TOOLCHAIN = TOOLCHAIN_ROOT / TRIPLET
 
 # This is not reliable, the version can be modified by setuptools at build time.
-distinfo = (
+DISTINFO = (
     pathlib.Path(__file__).resolve().parent.parent / f"ppbt-{__version__}.dist-info"
 )
 
-log = logging.getLogger(__name__)
+
+def extract_archive(to_dir, archive):
+    """
+    Extract an archive to a specific location.
+
+    :param to_dir: The directory to extract to
+    :type to_dir: str
+    :param archive: The archive to extract
+    :type archive: str
+    """
+    if archive.endswith("tgz"):
+        read_type = "r:gz"
+    elif archive.endswith("xz"):
+        read_type = "r:xz"
+    elif archive.endswith("bz2"):
+        read_type = "r:bz2"
+    else:
+        read_type = "r"
+    with tarfile.open(archive, read_type) as t:
+        t.extractall(to_dir)
 
 
 def extract(overwrite=False):
     """
     Extract the toolchain tarball.
     """
-    if toolchain.exists() and not overwrite:
+    if TOOLCHAIN.exists() and not overwrite:
         log.debug("Toolchain directory exists")
     else:
         log.info("Extract archive")
-        extract_archive(toolchain_root, str(archive))
-        record = distinfo / "RECORD"
+        extract_archive(TOOLCHAIN_ROOT, str(ARCHIVE))
+        record = DISTINFO / "RECORD"
         if record.exists():
             records = []
             log.info("Update pkg metadata")
             with open(record, "r") as fp:
                 for row in csv.reader(fp):
                     records.append(row)
-            with open(str(archive) + ".record", "r") as fp:
+            with open(str(ARCHIVE) + ".record", "r") as fp:
                 for row in csv.reader(fp):
                     records.append(row)
             records = sorted(records, key=lambda _: _[0])
@@ -57,18 +124,18 @@ def environ(auto_extract=False):
     """
     Toolchain build environment.
     """
-    if not toolchain.exists():
+    if not TOOLCHAIN.exists():
         if auto_extract:
             extract()
         else:
             raise RuntimeError("Toolchain not extracted")
-    basebin = toolchain / "bin" / triplet
+    basebin = TOOLCHAIN / "bin" / TRIPLET
     return {
-        "TOOLCHAIN_PATH": f"{toolchain}",
+        "TOOLCHAIN_PATH": f"{TOOLCHAIN}",
         "CC": f"{basebin}-gcc",
         "CXX": f"{basebin}-g++",
-        "CFLAGS": f"-I{toolchain}/{triplet}/sysroot/usr/include",
-        "CPPFLAGS": f"-I{toolchain}/{triplet}/sysroot/usr/include",
-        "CMAKE_FLAGS": f"-I{toolchain}/{triplet}/sysroot/usr/include",
-        "LDFLAGS": f"-L{toolchain}/{triplet}/sysroot/lib",
+        "CFLAGS": f"-I{TOOLCHAIN}/{TRIPLET}/sysroot/usr/include",
+        "CPPFLAGS": f"-I{TOOLCHAIN}/{TRIPLET}/sysroot/usr/include",
+        "CMAKE_FLAGS": f"-I{TOOLCHAIN}/{TRIPLET}/sysroot/usr/include",
+        "LDFLAGS": f"-L{TOOLCHAIN}/{TRIPLET}/sysroot/lib",
     }


### PR DESCRIPTION
We do not need the setuptools import used while building packages in ppbt.common. Having that import around breaks relenv runtime when trying to setup the toolchain.